### PR TITLE
Prod Error Message

### DIFF
--- a/lib/epochtalk_server_web/json/error_json.ex
+++ b/lib/epochtalk_server_web/json/error_json.ex
@@ -71,7 +71,7 @@ defmodule EpochtalkServerWeb.Controllers.ErrorJSON do
   defp format_error(status, message) when is_integer(status) and is_binary(message) do
     %{
       status: status,
-      message: message,
+      message: if(Mix.env() == :prod, do: "Something went wrong", else: message),
       error: Phoenix.Controller.status_message_from_template(to_string(status))
     }
   end

--- a/lib/epochtalk_server_web/json/error_json.ex
+++ b/lib/epochtalk_server_web/json/error_json.ex
@@ -71,7 +71,11 @@ defmodule EpochtalkServerWeb.Controllers.ErrorJSON do
   defp format_error(status, message) when is_integer(status) and is_binary(message) do
     %{
       status: status,
-      message: if(Application.get_env(:epochtalk_server, :env) == :dev, do: "Something went wrong", else: message),
+      message:
+        if(Application.get_env(:epochtalk_server, :env) == :dev,
+          do: "Something went wrong",
+          else: message
+        ),
       error: Phoenix.Controller.status_message_from_template(to_string(status))
     }
   end

--- a/lib/epochtalk_server_web/json/error_json.ex
+++ b/lib/epochtalk_server_web/json/error_json.ex
@@ -72,7 +72,7 @@ defmodule EpochtalkServerWeb.Controllers.ErrorJSON do
     %{
       status: status,
       message:
-        if(Application.get_env(:epochtalk_server, :env) == :dev,
+        if(Application.get_env(:epochtalk_server, :env) == :prod,
           do: "Something went wrong",
           else: message
         ),

--- a/lib/epochtalk_server_web/json/error_json.ex
+++ b/lib/epochtalk_server_web/json/error_json.ex
@@ -71,7 +71,7 @@ defmodule EpochtalkServerWeb.Controllers.ErrorJSON do
   defp format_error(status, message) when is_integer(status) and is_binary(message) do
     %{
       status: status,
-      message: if(Mix.env() == :prod, do: "Something went wrong", else: message),
+      message: if(Application.get_env(:epochtalk_server, :env) == :dev, do: "Something went wrong", else: message),
       error: Phoenix.Controller.status_message_from_template(to_string(status))
     }
   end


### PR DESCRIPTION
If in prod, remove error message from front end response and replace with "Something went wrong" to hide sensitive info 

This will still log the error correctly and is only done for display on the front end api response